### PR TITLE
Resolve #13 Update listener function

### DIFF
--- a/tasks/setPriority.js
+++ b/tasks/setPriority.js
@@ -1,0 +1,14 @@
+import { checkHighPriorityJobs, checklowhPriorityJobs } from "../dbConnection/getJobs.js";
+
+const setPriority = async (pool, client) => {
+    let priority = -1;
+
+    if((await checkHighPriorityJobs(pool, client)).length != 0){
+        return priority = 0;
+    }else if((await checklowhPriorityJobs(pool, client)).length != 0){
+        return priority = 1;
+    }
+  };
+
+
+  export{setPriority}

--- a/tasks/setPriority.js
+++ b/tasks/setPriority.js
@@ -1,14 +1,15 @@
-import { checkHighPriorityJobs, checklowhPriorityJobs } from "../dbConnection/getJobs.js";
+import {
+  checkHighPriorityJobs,
+  checklowhPriorityJobs,
+} from "../dbConnection/getJobs.js";
 
 const setPriority = async (pool, client) => {
-    let priority = -1;
+  if ((await checkHighPriorityJobs(pool, client)).length != 0) {
+    return 0;
+  }
+  if ((await checklowhPriorityJobs(pool, client)).length != 0) {
+    return 1;
+  }
+};
 
-    if((await checkHighPriorityJobs(pool, client)).length != 0){
-        return priority = 0;
-    }else if((await checklowhPriorityJobs(pool, client)).length != 0){
-        return priority = 1;
-    }
-  };
-
-
-  export{setPriority}
+export { setPriority };


### PR DESCRIPTION
I rewrote the listener function in this pull request to make it more organized. 

1. I add the function called setpriority to handle the order of jobs in the DB. If there is any high-priority job, the function will be returned early, not to keep searching for the other job. 

2. At the end of the listener function, I use the recursion function to keep listening to the job again in the next second. The reason to use the setTimeout function and wait 1 second is that there is rate limit in the exchange. If you are the VIP of the exchange, try to remove the setTimeout function.